### PR TITLE
More intuitive game URLs

### DIFF
--- a/app/controllers/games/ladder-new.js
+++ b/app/controllers/games/ladder-new.js
@@ -35,7 +35,10 @@ export default class GamesLadderNewController extends Controller {
         }
 
         // Success.
-        this.target.transitionTo('games.ladders-manage', this.model.game.id);
+        this.target.transitionTo(
+          'games.ladders-manage',
+          this.model.game.shortCode
+        );
       })
       .catch((error) => {
         setFormError(this.form, error.message);

--- a/app/models/game.js
+++ b/app/models/game.js
@@ -2,6 +2,17 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class GameModel extends Model {
   @attr('string') name;
+  @attr('string') shortCode;
 
   @hasMany('chart-type') chartTypes;
+}
+
+export function getGameByShortCode(store, shortCode) {
+  return store
+    .query('game', {
+      short_code: shortCode,
+    })
+    .then((games) => {
+      return games.objectAt(0);
+    });
 }

--- a/app/router.js
+++ b/app/router.js
@@ -8,11 +8,11 @@ export default class Router extends EmberRouter {
 
 Router.map(function () {
   this.route('games', function () {
-    this.route('show', { path: '/:game_id' });
-    this.route('chart-types', { path: '/:game_id/chart-types' });
-    this.route('filter-groups', { path: '/:game_id/filter-groups' });
-    this.route('ladder-new', { path: '/:game_id/ladder-new' });
-    this.route('ladders-manage', { path: '/:game_id/ladders-manage' });
+    this.route('show', { path: '/:game_code' });
+    this.route('chart-types', { path: '/:game_code/chart-types' });
+    this.route('filter-groups', { path: '/:game_code/filter-groups' });
+    this.route('ladder-new', { path: '/:game_code/ladder-new' });
+    this.route('ladders-manage', { path: '/:game_code/ladders-manage' });
   });
 
   this.route('charts', function () {

--- a/app/routes/games/chart-types.js
+++ b/app/routes/games/chart-types.js
@@ -1,17 +1,20 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
+import { getGameByShortCode } from '../../models/game';
 
 export default class GameChartTypesRoute extends Route {
   @service store;
 
   model(params) {
     return RSVP.hash({
-      chartTypes: this.store.query('chart-type', { game_id: params.game_id }),
-      filterGroups: this.store.query('filter-group', {
-        game_id: params.game_id,
+      chartTypes: this.store.query('chart-type', {
+        game_code: params.game_code,
       }),
-      game: this.store.findRecord('game', params.game_id),
+      filterGroups: this.store.query('filter-group', {
+        game_code: params.game_code,
+      }),
+      game: getGameByShortCode(this.store, params.game_code),
     });
   }
 }

--- a/app/routes/games/filter-groups.js
+++ b/app/routes/games/filter-groups.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
+import { getGameByShortCode } from '../../models/game';
 
 export default class GameFilterGroupsRoute extends Route {
   @service store;
@@ -8,9 +9,9 @@ export default class GameFilterGroupsRoute extends Route {
   model(params) {
     return RSVP.hash({
       filterGroups: this.store.query('filter-group', {
-        game_id: params.game_id,
+        game_code: params.game_code,
       }),
-      game: this.store.findRecord('game', params.game_id),
+      game: getGameByShortCode(this.store, params.game_code),
     });
   }
 }

--- a/app/routes/games/ladder-new.js
+++ b/app/routes/games/ladder-new.js
@@ -1,14 +1,17 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
+import { getGameByShortCode } from '../../models/game';
 
 export default class GamesLadderNewRoute extends Route {
   @service store;
 
   model(params) {
     return RSVP.hash({
-      chartGroups: this.store.query('chartGroup', { game_id: params.game_id }),
-      game: this.store.findRecord('game', params.game_id),
+      chartGroups: this.store.query('chartGroup', {
+        game_code: params.game_code,
+      }),
+      game: getGameByShortCode(this.store, params.game_code),
     });
   }
 }

--- a/app/routes/games/ladders-manage.js
+++ b/app/routes/games/ladders-manage.js
@@ -2,19 +2,20 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
+import { getGameByShortCode } from '../../models/game';
 
 export default class GamesLaddersRoute extends Route {
   @service store;
 
   model(params) {
     return RSVP.hash({
-      game: this.store.findRecord('game', params.game_id),
+      game: getGameByShortCode(this.store, params.game_code),
       mainLadders: this.store.query('ladder', {
-        game_id: params.game_id,
+        game_code: params.game_code,
         kind: 'main',
       }),
       sideLadders: this.store.query('ladder', {
-        game_id: params.game_id,
+        game_code: params.game_code,
         kind: 'side',
       }),
     });

--- a/app/routes/games/show.js
+++ b/app/routes/games/show.js
@@ -1,19 +1,20 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
+import { getGameByShortCode } from '../../models/game';
 
 export default class GamesShowRoute extends Route {
   @service store;
 
   model(params) {
     return RSVP.hash({
-      game: this.store.findRecord('game', params.game_id),
+      game: getGameByShortCode(this.store, params.game_code),
       mainLadders: this.store.query('ladder', {
-        game_id: params.game_id,
+        game_code: params.game_code,
         kind: 'main',
       }),
       sideLadders: this.store.query('ladder', {
-        game_id: params.game_id,
+        game_code: params.game_code,
         kind: 'side',
       }),
     });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -36,22 +36,20 @@
     <div id='game-selector'>
       <img src='{{this.rootURL}}assets/images/game_selector/choose_game.gif' alt="Choose game">
       <div>
-        {{#each (array 'climax' 'gpl' 'mv' 'x' 'gx' 'snes') as |game|}}
-          {{#if (eq game 'gx')}}
-            {{! Hardcoded ID for now... ideally we'd be able to get games by a short name (like 'gx') instead of a number ID later. }}
-            <LinkTo @route='games.show' @model='1'>
-              <img
-                src='{{this.rootURL}}assets/images/game_selector/unselected_{{game}}.gif'
-                alt='{{game}}'
-              />
-            </LinkTo>
-          {{else}}
+        {{#each (array 'gx' 'mv') as |game|}}
+          <LinkTo @route='games.show' @model={{game}}>
             <img
               src='{{this.rootURL}}assets/images/game_selector/unselected_{{game}}.gif'
               alt='{{game}}'
-              class='unavailable-game'
             />
-          {{/if}}
+          </LinkTo>
+        {{/each}}
+        {{#each (array 'climax' 'gpl' 'x' 'snes') as |game|}}
+          <img
+            src='{{this.rootURL}}assets/images/game_selector/unselected_{{game}}.gif'
+            alt='{{game}}'
+            class='unavailable-game'
+          />
         {{/each}}
       </div>
     </div>

--- a/app/templates/games/ladder-new.hbs
+++ b/app/templates/games/ladder-new.hbs
@@ -1,6 +1,6 @@
 <h1>
   Create ladder for:
-  <LinkTo @route='games.ladders-manage' @model={{@model.game.id}}>
+  <LinkTo @route='games.ladders-manage' @model={{@model.game.shortCode}}>
     {{@model.game.name}}
   </LinkTo>
 </h1>

--- a/app/templates/games/ladders-manage.hbs
+++ b/app/templates/games/ladders-manage.hbs
@@ -1,5 +1,5 @@
 <h1>
-  <LinkTo @route='games.show' @model={{@model.game.id}}>
+  <LinkTo @route='games.show' @model={{@model.game.shortCode}}>
     {{@model.game.name}}
   </LinkTo>
   - Manage Ladders
@@ -33,6 +33,6 @@
 
 <div class='error-message' id='ladder-delete-error'></div>
 
-<LinkTo @route='games.ladder-new' @model={{@model.game.id}}>
+<LinkTo @route='games.ladder-new' @model={{@model.game.shortCode}}>
   Create ladder
 </LinkTo>

--- a/app/templates/games/show.hbs
+++ b/app/templates/games/show.hbs
@@ -59,17 +59,17 @@
 
     <ul>
       <li>
-        <LinkTo @route='games.chart-types' @model={{@model.game.id}}>
+        <LinkTo @route='games.chart-types' @model={{@model.game.shortCode}}>
           Chart types admin
         </LinkTo>
       </li>
       <li>
-        <LinkTo @route='games.filter-groups' @model={{@model.game.id}}>
+        <LinkTo @route='games.filter-groups' @model={{@model.game.shortCode}}>
           Filter groups admin
         </LinkTo>
       </li>
       <li>
-        <LinkTo @route='games.ladders-manage' @model={{@model.game.id}}>
+        <LinkTo @route='games.ladders-manage' @model={{@model.game.shortCode}}>
           Ladders admin
         </LinkTo>
       </li>

--- a/app/templates/ladders/show.hbs
+++ b/app/templates/ladders/show.hbs
@@ -1,7 +1,7 @@
 {{page-title (concat @model.ladder.name ' ladder: Home')}}
 
 <div class='general-content-box'>
-  <LinkTo @route='games.show' @model={{@model.ladder.game.id}}>
+  <LinkTo @route='games.show' @model={{@model.ladder.game.shortCode}}>
     <h2>{{@model.ladder.game.name}}</h2>
   </LinkTo>
   <h1>{{@model.ladder.name}} Ladder</h1>


### PR DESCRIPTION
For issue #67.

- Make game URLs based on the game short code (a new field) rather than the game id.
- Add F-Zero MV to the header's available games, now that activating more games no longer requires hard-coding numeric ids.