### PR TITLE
Full refresh going from view-forum to view-topic

### DIFF
--- a/app/templates/old-forum/view-forum.hbs
+++ b/app/templates/old-forum/view-forum.hbs
@@ -34,9 +34,10 @@
 
           {{topic.titlePrefix}}
 
-          <LinkTo @route='old-forum.view-topic' @query={{hash t=topic.id}}>
+          {{! LinkTo here makes poll results not filtered by poll ID, so use BasicLink. }}
+          <BasicLink @route='old-forum.view-topic' @query={{hash t=topic.id}}>
             {{topic.titleDisplay}}
-          </LinkTo>
+          </BasicLink>
 
           {{#if topic.hasMultiplePages}}
             [ Page:


### PR DESCRIPTION
The idea that not doing this can result in unfiltered data (poll results in this case) is kind of disturbing actually. Guess I should default to BasicLink, not LinkTo, until we somehow get to the bottom of this.